### PR TITLE
Adds bugfix for the xml issues and description added for missing demos 

### DIFF
--- a/matter_demos.xml
+++ b/matter_demos.xml
@@ -37,7 +37,7 @@
     <property key="demos.imageFile" value="Examples/lighting-app-thread/BRD4164A/chip-efr32-lighting-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo</description>
    </demo>
   <demo name="brd4166a.demo.light_app_thread" label="Matter - Light App">
     <property key="demos.blurb" value="Matter - Light App"/>
@@ -46,7 +46,7 @@
     <property key="demos.imageFile" value="Examples/lighting-app-thread/BRD4166A/chip-efr32-lighting-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo</description>
    </demo>   
   <demo name="brd4170a.demo.light_app_thread" label="Matter - Light App">
     <property key="demos.blurb" value="Matter - Light App"/>
@@ -55,7 +55,7 @@
     <property key="demos.imageFile" value="Examples/lighting-app-thread/BRD4170A/chip-efr32-lighting-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo</description>
    </demo>    
   <demo name="brd4186a.demo.light_app_thread" label="Matter - Light App">
     <property key="demos.blurb" value="Matter - Light App"/>
@@ -64,7 +64,7 @@
     <property key="demos.imageFile" value="Examples/lighting-app-thread/BRD4186A/chip-efr32-lighting-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo</description>
    </demo>    
   <demo name="brd4186c.demo.light_app_thread" label="Matter - Light App">
     <property key="demos.blurb" value="Matter - Light App"/>
@@ -73,7 +73,7 @@
     <property key="demos.imageFile" value="Examples/lighting-app-thread/BRD4186C/chip-efr32-lighting-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo</description>
    </demo>      
   <demo name="brd4187a.demo.light_app_thread" label="Matter - Light App">
     <property key="demos.blurb" value="Matter - Light App"/>
@@ -82,7 +82,7 @@
     <property key="demos.imageFile" value="Examples/lighting-app-thread/BRD4187A/chip-efr32-lighting-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo</description>
    </demo> 
   <demo name="brd4187c.demo.light_app_thread" label="Matter - Light App">
     <property key="demos.blurb" value="Matter - Light App"/>
@@ -91,7 +91,7 @@
     <property key="demos.imageFile" value="Examples/lighting-app-thread/BRD4187C/chip-efr32-lighting-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo</description>
    </demo>    
   <demo name="brd4161a.demo.light_app_wifi_wf200" label="Matter - Light App">
     <property key="demos.blurb" value="Matter - Light App"/>
@@ -101,7 +101,7 @@
     <property key="core.readmeFiles" value="docs/matter_readme.html"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>
-    <description> This is a Matter Lighting Application demo </description>
+    <description> This is a Matter Lighting Application demo WF200</description>
    </demo>
   <demo name="brd4162a.demo.light_app_wifi_wf200" label="Matter - Light App">
     <property key="demos.blurb" value="Matter - Light App"/>
@@ -111,7 +111,7 @@
     <property key="core.readmeFiles" value="docs/matter_readme.html"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>
-    <description> This is a Matter Lighting Application demo </description>
+    <description> This is a Matter Lighting Application demo WF200</description>
    </demo> 
   <demo name="brd4163a.demo.light_app_wifi_wf200" label="Matter - Light App">
     <property key="demos.blurb" value="Matter - Light App"/>
@@ -121,7 +121,7 @@
     <property key="core.readmeFiles" value="docs/matter_readme.html"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>
-    <description> This is a Matter Lighting Application demo </description>
+    <description> This is a Matter Lighting Application demo WF200</description>
    </demo>
   <demo name="brd4164a.demo.light_app_wifi_wf200" label="Matter - Light App">
     <property key="demos.blurb" value="Matter - Light App"/>
@@ -131,7 +131,7 @@
     <property key="core.readmeFiles" value="docs/matter_readme.html"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>
-    <description> This is a Matter Lighting Application demo </description>
+    <description> This is a Matter Lighting Application demo WF200</description>
    </demo>
   <demo name="brd4161a.demo.light_app_wifi_rs9116" label="Matter - Light App">
     <property key="demos.blurb" value="Matter - Light App"/>
@@ -140,7 +140,7 @@
     <property key="demos.imageFile" value="Examples/lighting-app-wifi/rs9116/BRD4161A/chip-efr32-lighting-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description> This is a Matter Lighting Application demo RS9116 </description>
    </demo>
   <demo name="brd4162a.demo.light_app_wifi_rs9116" label="Matter - Light App">
     <property key="demos.blurb" value="Matter - Light App"/>
@@ -149,7 +149,7 @@
     <property key="demos.imageFile" value="Examples/lighting-app-wifi/rs9116/BRD4162A/chip-efr32-lighting-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description> This is a Matter Lighting Application demo RS9116 </description>
    </demo>  
   <demo name="brd41643.demo.light_app_wifi_rs9116" label="Matter - Light App">
     <property key="demos.blurb" value="Matter - Light App"/>
@@ -158,7 +158,7 @@
     <property key="demos.imageFile" value="Examples/lighting-app-wifi/rs9116/BRD4163A/chip-efr32-lighting-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description> This is a Matter Lighting Application demo RS9116 </description>
    </demo> 
   <demo name="brd4164a.demo.light_app_wifi_rs9116" label="Matter - Light App">
     <property key="demos.blurb" value="Matter - Light App"/>
@@ -167,7 +167,7 @@
     <property key="demos.imageFile" value="Examples/lighting-app-wifi/rs9116/BRD4164A/chip-efr32-lighting-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description> This is a Matter Lighting Application demo RS9116 </description>
    </demo> 
   <demo name="brd4186c.demo.light_app_wifi_rs9116" label="Matter - Light App">
     <property key="demos.blurb" value="Matter - Light App"/>
@@ -176,7 +176,7 @@
     <property key="demos.imageFile" value="Examples/lighting-app-wifi/rs9116/BRD4186C/chip-efr32-lighting-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description> This is a Matter Lighting Application demo RS9116 </description>
    </demo>     
   <demo name="brd4187c.demo.light_app_wifi_rs9116" label="Matter - Light App">
     <property key="demos.blurb" value="Matter - Light App"/>
@@ -185,7 +185,7 @@
     <property key="demos.imageFile" value="Examples/lighting-app-wifi/rs9116/BRD4187C/chip-efr32-lighting-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description> This is a Matter Lighting Application demo RS9116 </description>
    </demo>    
   <demo name="brd4186a.demo.light_app_wifi_rs9116" label="Matter - Light App">
     <property key="demos.blurb" value="Matter - Light App"/>
@@ -194,7 +194,7 @@
     <property key="demos.imageFile" value="Examples/lighting-app-wifi/rs9116/BRD4186A/chip-efr32-lighting-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description> This is a Matter Lighting Application demo RS9116 </description>
    </demo>     
   <demo name="brd4187a.demo.light_app_wifi_rs9116" label="Matter - Light App">
     <property key="demos.blurb" value="Matter - Light App"/>
@@ -203,7 +203,7 @@
     <property key="demos.imageFile" value="Examples/lighting-app-wifi/rs9116/BRD4187A/chip-efr32-lighting-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description> This is a Matter Lighting Application demo RS9116 </description>
    </demo> 
   <demo name="brd2601b.demo.lock_app_thread" label="Matter - Lock App">
     <property key="demos.blurb" value="Matter - Lock App"/>
@@ -242,7 +242,7 @@
     <property key="demos.imageFile" value="Examples/lock-app-thread/BRD4164A/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo</description>
    </demo>
   <demo name="brd4166a.demo.lock_app_thread" label="Matter - Lock App">
     <property key="demos.blurb" value="Matter - Lock App"/>
@@ -251,7 +251,7 @@
     <property key="demos.imageFile" value="Examples/lock-app-thread/BRD4166A/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo</description>
    </demo> 
   <demo name="brd4170a.demo.lock_app_thread" label="Matter - Lock App">
     <property key="demos.blurb" value="Matter - Lock App"/>
@@ -260,7 +260,7 @@
     <property key="demos.imageFile" value="Examples/lock-app-thread/BRD4170A/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo</description>
    </demo>  
   <demo name="brd4186a.demo.lock_app_thread" label="Matter - Lock App">
     <property key="demos.blurb" value="Matter - Lock App"/>
@@ -269,7 +269,7 @@
     <property key="demos.imageFile" value="Examples/lock-app-thread/BRD4186A/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo</description>
    </demo>  
   <demo name="brd4186c.demo.lock_app_thread" label="Matter - Lock App">
     <property key="demos.blurb" value="Matter - Lock App"/>
@@ -278,7 +278,7 @@
     <property key="demos.imageFile" value="Examples/lock-app-thread/BRD4186C/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo</description>
    </demo>  
   <demo name="brd4187a.demo.lock_app_thread" label="Matter - Lock App">
     <property key="demos.blurb" value="Matter - Lock App"/>
@@ -287,7 +287,7 @@
     <property key="demos.imageFile" value="Examples/lock-app-thread/BRD4187A/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo</description>
    </demo>
   <demo name="brd4187c.demo.lock_app_thread" label="Matter - Lock App">
     <property key="demos.blurb" value="Matter - Lock App"/>
@@ -296,7 +296,7 @@
     <property key="demos.imageFile" value="Examples/lock-app-thread/BRD4187C/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo</description>
    </demo>      
   <demo name="brd4161a.demo.lock_app_wifi_wf200" label="Matter - Lock App">
     <property key="demos.blurb" value="Matter - Lock App"/>
@@ -306,7 +306,7 @@
     <property key="core.readmeFiles" value="docs/matter_readme.html"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description>This is a Matter Lock Application demo</description>
+    <description>This is a Matter Lock Application demo WF200</description>
    </demo>
   <demo name="brd4162a.demo.lock_app_wifi_wf200" label="Matter - Lock App">
     <property key="demos.blurb" value="Matter - Lock App"/>
@@ -315,7 +315,7 @@
     <property key="demos.imageFile" value="Examples/lock-app-wifi/wf200/BRD4162A/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lock Application demo WF200</description>
    </demo>
   <demo name="brd4163a.demo.lock_app_wifi_wf200" label="Matter - Lock App">
     <property key="demos.blurb" value="Matter - Lock App"/>
@@ -324,16 +324,16 @@
     <property key="demos.imageFile" value="Examples/lock-app-wifi/wf200/BRD4163A/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lock Application demo WF200</description>
    </demo>
   <demo name="brd4164a.demo.lock_app_wifi_wf200" label="Matter - Lock App">
     <property key="demos.blurb" value="Matter - Lock App"/>
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4164a"/>
-    <property key="demos.imageFile" value="Examples/lock-app-thread/BRD4164A/chip-efr32-lock-example.s37"/>
+    <property key="demos.imageFile" value="Examples/lock-app-wifi/wf200/BRD4164A/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lock Application demo WF200</description>
    </demo> 
   <demo name="brd4161a.demo.lock_app_wifi_rs9116" label="Matter - Lock App">
     <property key="demos.blurb" value="Matter - Lock App"/>
@@ -342,7 +342,7 @@
     <property key="demos.imageFile" value="Examples/lock-app-wifi/rs9116/BRD4161A/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo RS9116</description>
    </demo>  
   <demo name="brd4162a.demo.lock_app_wifi_rs9116" label="Matter - Lock App">
     <property key="demos.blurb" value="Matter - Lock App"/>
@@ -351,7 +351,7 @@
     <property key="demos.imageFile" value="Examples/lock-app-wifi/rs9116/BRD4162A/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo RS9116</description>
    </demo>
   <demo name="brd4163a.demo.lock_app_wifi_rs9116" label="Matter - Lock App">
     <property key="demos.blurb" value="Matter - Lock App"/>
@@ -360,7 +360,7 @@
     <property key="demos.imageFile" value="Examples/lock-app-wifi/rs9116/BRD4163A/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo RS9116</description>
    </demo> 
   <demo name="brd4164a.demo.lock_app_wifi_rs9116" label="Matter - Lock App">
     <property key="demos.blurb" value="Matter - Lock App"/>
@@ -369,7 +369,7 @@
     <property key="demos.imageFile" value="Examples/lock-app-wifi/rs9116/BRD4164A/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo RS9116</description>
    </demo>    
   <demo name="brd4186c.demo.lock_app_wifi_rs9116" label="Matter - Lock App">
     <property key="demos.blurb" value="Matter - Lock App"/>
@@ -378,158 +378,159 @@
     <property key="demos.imageFile" value="Examples/lock-app-wifi/rs9116/BRD4186C/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo RS9116</description>
    </demo>  
-  <demo name="brd4187c.demo.lock_app_wifi" label="Matter - Lock App">
+  <demo name="brd4187c.demo.lock_app_wifi_rs9116" label="Matter - Lock App">
     <property key="demos.blurb" value="Matter - Lock App"/>
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4187c"/>
     <property key="demos.imageFile" value="Examples/lock-app-wifi/rs9116/BRD4187C/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo RS9116</description>
    </demo>
-  <demo name="brd2601b.demo.light_switch_app_thread" label="Matter - Lock App">
+  <demo name="brd2601b.demo.light_switch_app_thread" label="Matter - Light Switch App">
     <property key="demos.blurb" value="Matter - Lock App"/>
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd2601b"/>
     <property key="demos.imageFile" value="Examples/light-switch-app-thread/BRD2601B/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo</description>
    </demo>  
-  <demo name="brd2703A.demo.light_switch_app_thread" label="Matter - Lock App">
+  <demo name="brd2703A.demo.light_switch_app_thread" label="Matter - Light Switch App">
     <property key="demos.blurb" value="Matter - Lock App"/>
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd2703a"/>
     <property key="demos.imageFile" value="Examples/light-switch-app-thread/BRD2703A/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo</description>
    </demo>
-  <demo name="brd4161a.demo.light_switch_app_thread" label="Matter - Lock App">
+  <demo name="brd4161a.demo.light_switch_app_thread" label="Matter - Light Switch App">
     <property key="demos.blurb" value="Matter - Lock App"/>
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4161a"/>
     <property key="demos.imageFile" value="Examples/light-switch-app-thread/BRD4161A/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo</description>
    </demo>
-  <demo name="brd4164a.demo.light_switch_app_thread" label="Matter - Lock App">
+  <demo name="brd4164a.demo.light_switch_app_thread" label="Matter - Light Switch App">
     <property key="demos.blurb" value="Matter - Lock App"/>
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4164a"/>
     <property key="demos.imageFile" value="Examples/light-switch-app-thread/BRD4164A/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo</description>
    </demo>     
-  <demo name="brd4166a.demo.light_switch_app_thread" label="Matter - Lock App">
+  <demo name="brd4166a.demo.light_switch_app_thread" label="Matter - Light Switch App">
     <property key="demos.blurb" value="Matter - Lock App"/>
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4166a"/>
     <property key="demos.imageFile" value="Examples/light-switch-app-thread/BRD4166A/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo</description>
    </demo>  
-  <demo name="brd4186c.demo.light_switch_app_thread" label="Matter - Lock App">
+  <demo name="brd4186c.demo.light_switch_app_thread" label="Matter - Light Switch App">
     <property key="demos.blurb" value="Matter - Lock App"/>
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4186c"/>
     <property key="demos.imageFile" value="Examples/light-switch-app-thread/BRD4186C/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo</description>
    </demo>   
-  <demo name="brd4187c.demo.light_switch_app_thread" label="Matter - Lock App">
+  <demo name="brd4187c.demo.light_switch_app_thread" label="Matter - Light Switch App">
     <property key="demos.blurb" value="Matter - Lock App"/>
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4187c"/>
     <property key="demos.imageFile" value="Examples/light-switch-app-thread/BRD4187C/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>
+    <description>This is a Matter Lighting Application demo</description>
    </demo>  
-  <demo name="brd2601b.demo.window_app_thread" label="Matter - Lock App">
+  <demo name="brd2601b.demo.window_app_thread" label="Matter - Light Switch App">
     <property key="demos.blurb" value="Matter - Lock App"/>
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd2601b"/>
     <property key="demos.imageFile" value="Examples/light-switch-app-thread/BRD2601B/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-   <description></description>
-  <demo name="brd2703a.demo.window_app_thread" label="Matter - Lock App">
+   <description>This is a Matter Lighting Application demo</description>
+   </demo>
+  <demo name="brd2703a.demo.window_app_thread" label="Matter - Window App">
     <property key="demos.blurb" value="Matter - Lock App"/>
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd2703a"/>
     <property key="demos.imageFile" value="Examples/window-app-thread/BRD2703A/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>  
+    <description>This is a Matter Lighting Application demo</description>
    </demo> 
-  <demo name="brd4161a.demo.window_app_thread" label="Matter - Lock App">
+  <demo name="brd4161a.demo.window_app_thread" label="Matter - Window App">
     <property key="demos.blurb" value="Matter - Lock App"/>
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4161a"/>
     <property key="demos.imageFile" value="Examples/window-app-thread/BRD4161A/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>  
+    <description>This is a Matter Lighting Application demo</description>
    </demo> 
-  <demo name="brd4164a.demo.window_app_thread" label="Matter - Lock App">
+  <demo name="brd4164a.demo.window_app_thread" label="Matter - Window App">
     <property key="demos.blurb" value="Matter - Lock App"/>
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4164a"/>
     <property key="demos.imageFile" value="Examples/window-app-thread/BRD4164A/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>  
+    <description>This is a Matter Lighting Application demo</description>
    </demo> 
-  <demo name="brd4166a.demo.window_app_thread" label="Matter - Lock App">
+  <demo name="brd4166a.demo.window_app_thread" label="Matter - Window App">
     <property key="demos.blurb" value="Matter - Lock App"/>
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4166a"/>
     <property key="demos.imageFile" value="Examples/window-app-thread/BRD4166A/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>  
+    <description>This is a Matter Lighting Application demo</description>
    </demo> 
-  <demo name="brd4186a.demo.window_app_thread" label="Matter - Lock App">
+  <demo name="brd4186a.demo.window_app_thread" label="Matter - Window App">
     <property key="demos.blurb" value="Matter - Lock App"/>
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4186a"/>
     <property key="demos.imageFile" value="Examples/window-app-thread/BRD4186A/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>  
+    <description>This is a Matter Lighting Application demo</description>
    </demo> 
-  <demo name="brd4186c.demo.window_app_thread" label="Matter - Lock App">
+  <demo name="brd4186c.demo.window_app_thread" label="Matter - Window App">
     <property key="demos.blurb" value="Matter - Lock App"/>
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4186c"/>
     <property key="demos.imageFile" value="Examples/window-app-thread/BRD4186C/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>  
+    <description>This is a Matter Lighting Application demo</description>
    </demo> 
-  <demo name="brd4187a.demo.window_app_thread" label="Matter - Lock App">
+  <demo name="brd4187a.demo.window_app_thread" label="Matter - Window App">
     <property key="demos.blurb" value="Matter - Lock App"/>
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4187a"/>
     <property key="demos.imageFile" value="Examples/window-app-thread/BRD4187A/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>  
+    <description>This is a Matter Lighting Application demo</description>
    </demo> 
-  <demo name="brd4187c.demo.window_app_thread" label="Matter - Lock App">
+  <demo name="brd4187c.demo.window_app_thread" label="Matter - Window App">
     <property key="demos.blurb" value="Matter - Lock App"/>
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4187c"/>
     <property key="demos.imageFile" value="Examples/window-app-thread/BRD4187C/chip-efr32-lock-example.s37"/>
     <property key="core.quality" value="PRODUCTION"/>
     <property key="filters" value="Wireless\ Technology|Matter"/>    
-    <description></description>  
+    <description>This is a Matter Lighting Application demo</description>
    </demo> 
 </demos>


### PR DESCRIPTION
Below are the modifications made in matter_demos.xml
1. </demo> tag is missed due to which demo apps are not shown in Studio GUI.
2. Added description for the missing ones.
3. Demo name Labels have been corrected for window app and light switch app.
4. Path for brd4164a.demo.lock_app_wifi_wf200 was pointing to thread binaries.